### PR TITLE
Add missing 'endswitch', reclassify 'function' as structure instead of control keyword

### DIFF
--- a/Syntaxes/Octave.tmLanguage
+++ b/Syntaxes/Octave.tmLanguage
@@ -507,7 +507,7 @@
 			<key>match</key>
 			<string>(?x)
 				(?&lt;!\.)\b(all_va_args|break|case|catch|continue|else|end|for|parfor|elseif
-				|end_try_catch|end_unwind_protect|endfor|endparfor|endfunction|endif|endwhile
+				|end_try_catch|end_unwind_protect|endfor|endparfor|endfunction|endif|endswitch|endwhile
 				|global|gplot|gsplot|if|otherwise|persistent|replot|return|static
 				|start|startat|stop|switch|try|until|unwind_protect|unwind_protect_cleanup
 				|varargin|varargout|wait|while

--- a/Syntaxes/Octave.tmLanguage
+++ b/Syntaxes/Octave.tmLanguage
@@ -507,7 +507,7 @@
 			<key>match</key>
 			<string>(?x)
 				(?&lt;!\.)\b(all_va_args|break|case|catch|continue|else|end|for|parfor|elseif
-				|end_try_catch|end_unwind_protect|endfor|endparfor|endfunction|endif|endswitch|endwhile
+				|end_try_catch|end_unwind_protect|endfor|endparfor|endif|endswitch|endwhile
 				|global|gplot|gsplot|if|otherwise|persistent|replot|return|static
 				|start|startat|stop|switch|try|until|unwind_protect|unwind_protect_cleanup
 				|varargin|varargout|wait|while
@@ -520,8 +520,8 @@
 		  <key>comment</key>
 			<string>Structure keywords</string>
 			<key>match</key>
-			<string>(?x)\b(classdef|endclassdef|endevents|endenumeration|endmethods|endproperties
-				|enumeration|events|methods|properties)</string>
+			<string>(?x)\b(classdef|endclassdef|endenumeration|endevents|endfunction|endmethods
+				|endproperties|enumeration|events|function|methods|properties)</string>
 			<key>name</key>
 			<string>keyword.structure.octave</string>
 		</dict>


### PR DESCRIPTION
Reclassifies 'function' as a structure keyword, because (IMHO) it's more like a classdef definition or properties section than it is like control-flow mechanism such as if/while/for/try. The Octave editor doesn't seem to make a distinction between those types of keywords, but VS Code and I assume linguist do, and I think this arrangement makes more sense for tools that do support that distinction.

It looks like the 'function' keyword was missing from the control/structure keywords in the first place, too, and relying on other highlighting mechanisms to take care of it. This change moves 'endfunction' from the control keywords to structure keywords, and adds 'function' to go with it.

Changes the order of the structure keywords a bit to alphabetize them (like other keyword lists are), to make things easier to find, and mechanically determine where to insert new things.

These changes are taken from these commits to vscode-octave-hacking, on the WIP/early-2024 branch. That's still a work branch, but it's open because I'm still making changes to the VS Code-specific logic of that module. I'm pretty confident these grammar-only changes are good.